### PR TITLE
Add queues access.

### DIFF
--- a/lib/bunny_mock/channel.rb
+++ b/lib/bunny_mock/channel.rb
@@ -224,6 +224,17 @@ module BunnyMock
       @connection.register_queue queue
     end
 
+
+    ##
+    # Access the connection object queue list as a pass-through.
+    #
+    # @return [Hash] Queues
+    # @api public
+    #
+    def queues
+      @connection.queues
+    end
+
     ##
     # Create a new {BunnyMock::Queue} instance with no name
     #


### PR DESCRIPTION
We're just adding access to the queues as in the actual gem here - nothing but a pass-through to match the API calls.